### PR TITLE
Change log level of run_traces results to debug

### DIFF
--- a/automate.py
+++ b/automate.py
@@ -88,7 +88,7 @@ class Automate:
                     results.append(circuit)
             except KeyError:
                 results.append(circuit)
-        log.info('Results %s, size %s' % (results, len(self._circuits)))
+        log.debug('Results %s, size %s' % (results, len(self._circuits)))
         return results
 
     def get_circuit(self, circuit):


### PR DESCRIPTION
Fixes #7

### Description of the change

Change the logging level of run_traces() results to debug instead of info. The results are still returned to the requester.

### Release notes

N/A