### PR TITLE
Fix comparison of endpoints when an endpoint does not provide all necessary fields

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -112,7 +112,11 @@ def clean_circuits(circuits, controller):
 def _compare_endpoints(endpoint1, endpoint2):
     if endpoint1['dpid'] != endpoint2['dpid']:
         return False
-    if endpoint1['in_port'] != endpoint2['out_port']:
+    if (
+        'in_port' not in endpoint1
+        or 'out_port' not in endpoint2
+        or endpoint1['in_port'] != endpoint2['out_port']
+    ):
         return False
     if 'in_vlan' in endpoint1 and 'out_vlan' in endpoint2:
         if endpoint1['in_vlan'] != endpoint2['out_vlan']:


### PR DESCRIPTION
Fixes #6 

### Description of the change

The comparison of two endpoints could lead to an Exception when the endpoints does not provide enough information. Endpoints are auto-discovered from flow_stats received, so it might not even be an actual endpoint. The change was made to consider incomplete endpoint information as not equal.

### Release notes

N/A