### PR TITLE
Adjust requirements to remove napps and add requests

### DIFF
--- a/requirements/run.in
+++ b/requirements/run.in
@@ -1,2 +1,1 @@
-git+https://github.com/amlight/scheduler@master#egg=amlight-scheduler
-git+https://github.com/amlight/flow_stats@master#egg=amlight-flow_stats
+requests


### PR DESCRIPTION
This PR does some adjustments on the `requirements/run.in` by removing napps amlight/flow_stats and amlight/scheduler (they are actually listed on kytos.json file). Also, I've added the lib requests, which are used by automate function.