### PR TITLE
Adding settings to enable/disable find_circuits in flows

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,4 +168,5 @@ class Main(KytosNApp):
     def update_circuits(self, event):
         """Update the list of circuits after a flow change."""
         # pylint: disable=unused-argument
-        self.automate.find_circuits()
+        if settings.FIND_CIRCUITS_IN_FLOWS:
+            self.automate.find_circuits()

--- a/settings.py
+++ b/settings.py
@@ -8,6 +8,10 @@ IMPORTANT_CIRCUITS = []
 IMPORTANT_CIRCUITS_TRIGGER = 'interval'
 IMPORTANT_CIRCUITS_ARGS = {'seconds': 20}
 
+# Enable/Disables a routine that search for circuits upon receiving
+# amlight/flow_stats.flows_updated Kytos event
+FIND_CIRCUITS_IN_FLOWS = False
+
 SDNTRACE_URL = 'http://localhost:8181/api/amlight/sdntrace/trace'
 
 SLACK_CHANNEL = 'of_notifications'


### PR DESCRIPTION
This PR relates to issue #10. It creates a new setting, `FIND_CIRCUITS_IN_FLOWS`, which allows the operator to enable or disable the `find_circuits` routine. The find_circuits procedure has been shown to consume too many resources while finding circuits in the Flows. 